### PR TITLE
12.0 afc 338

### DIFF
--- a/edi_af_aisf_rask/__manifest__.py
+++ b/edi_af_aisf_rask/__manifest__.py
@@ -33,6 +33,7 @@
     },
     'data': [
         'data/edi_route_data.xml',
+        'data/server_action.xml',
         'views/edi_af_aisf_rask_views.xml',
     ],
     'application': False,

--- a/edi_af_aisf_rask/data/server_action.xml
+++ b/edi_af_aisf_rask/data/server_action.xml
@@ -6,7 +6,7 @@
         <field name="state">code</field>
         <field name="code">
 for partner in records:
-    partner.rask_controller(partner.customer_id,partner.social_security_number,partner.former_social_security_number,'edi_af_as_rask')</field>
+    partner.rask_controller(partner.customer_id,partner.social_security_number,None,'edi_af_as_rask')</field>
     </record>
 
     <function name="create_action" model="ir.actions.server">
@@ -21,7 +21,7 @@ for partner in records:
         <field name="state">code</field>
         <field name="code">
 for partner in records:
-    partner.rask_controller(partner.customer_id,partner.social_security_number,partner.former_social_security_number,'edi_af_as_rask')</field>
+    partner.rask_controller(partner.customer_id,partner.social_security_number,None,'edi_af_as_rask')</field>
     </record>
 
     <function name="create_action" model="ir.actions.server">

--- a/edi_af_aisf_rask/data/server_action.xml
+++ b/edi_af_aisf_rask/data/server_action.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="update_customer_number" model="ir.actions.server">
+        <field name="name">Update Customer Number</field>
+        <field name="model_id" ref="account.model_res_partner"/>
+        <field name="state">code</field>
+        <field name="code">
+for partner in records:
+    partner.rask_controller(partner.customer_id,partner.social_security_number,partner.former_social_security_number,'edi_af_as_rask')</field>
+    </record>
+
+    <function name="create_action" model="ir.actions.server">
+        <value model="ir.actions.server" search="[
+            ('id', 'in', [ref('update_customer_number')]),
+            ]"/>
+    </function>
+
+    <record id="update_customer_number_all" model="ir.actions.server">
+        <field name="name">Update ALL Customer Number</field>
+        <field name="model_id" ref="account.model_res_partner"/>
+        <field name="state">code</field>
+        <field name="code">
+for partner in records:
+    partner.rask_controller(partner.customer_id,partner.social_security_number,partner.former_social_security_number,'edi_af_as_rask')</field>
+    </record>
+
+    <function name="create_action" model="ir.actions.server">
+        <value model="ir.actions.server" search="[
+            ('id', 'in', [ref('update_customer_number_all')]),
+            ]"/>
+    </function>
+
+</odoo>
+

--- a/edi_af_bar_arbetsuppgifter/__init__.py
+++ b/edi_af_bar_arbetsuppgifter/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import messages

--- a/edi_af_bar_arbetsuppgifter/__manifest__.py
+++ b/edi_af_bar_arbetsuppgifter/__manifest__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution, third party addon
+#    Copyright (C) 2004-2020 Vertel AB (<http://vertel.se>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'EDI AF AS Bär Arbetsuppgifter',
+    'version': '0.1',
+    'category': 'edi',
+    'summary': 'EDI AF  ',
+    'licence': 'AGPL-3',
+    'description': """ """,
+    'author': 'Vertel AB',
+    'website': 'http://www.vertel.se',
+    'depends': ['edi_route', 'edi_route_ipf'],
+    'data': [
+        'data/edi_route_data.xml',
+        'views/edi_af_as_notes_views.xml',
+    ],
+    'application': False,
+    'installable': True,
+}
+# vim:expandtab:smartindent:tabstop=4s:softtabstop=4:shiftwidth=4:

--- a/edi_af_bar_arbetsuppgifter/data/edi_route_data.xml
+++ b/edi_af_bar_arbetsuppgifter/data/edi_route_data.xml
@@ -1,0 +1,25 @@
+<openerp>
+    <data noupdate="1">
+
+        <record id="asok_note_post_route" model="edi.route">
+            <field name="name">AF Asok: post note route</field>
+            <field name="partner_id" ref="base.main_partner"/>
+            <field name="active" eval="True"/>
+            <field name="protocol">ipf</field>
+            <field name="route_type">edi_af_as_notes_post</field>
+        </record>
+
+        <record id="asok_daily_notes" model="edi.message.type">
+            <field name="name"></field>
+            <field name="target"></field>
+            <field name="type_mapping">{{url}}:{{port}}/{path}?client_id={{client}}&amp;client_secret={{secret}}&amp;</field>
+        </record>
+
+        <record id="edi_af_as_notes_post" model="edi.message.type">
+            <field name="name">AF Asok daily note post</field>
+            <field name="target">ais-f-daganteckningar/v1/anteckning</field>
+            <field name="type_mapping">{{url}}:{{port}}/{path}?client_id={{client}}&amp;client_secret={{secret}}</field>
+        </record> 
+
+    </data>
+</openerp>

--- a/edi_af_bar_arbetsuppgifter/messages/__init__.py
+++ b/edi_af_bar_arbetsuppgifter/messages/__init__.py
@@ -1,0 +1,3 @@
+# import messages here
+from . import af_get_as_note
+from . import af_post_as_note

--- a/edi_af_bar_arbetsuppgifter/messages/af_get_as_note.py
+++ b/edi_af_bar_arbetsuppgifter/messages/af_get_as_note.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution, third party addon
+#    Copyright (C) 2004-2020 Vertel AB (<http://vertel.se>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from odoo import models, fields, api, _
+from datetime import datetime, timedelta
+import json
+import pytz
+import ast
+
+import logging
+_logger = logging.getLogger(__name__)
+
+LOCAL_TZ = 'Europe/Stockholm'
+
+class edi_message(models.Model):
+    _inherit='edi.message'
+            
+    @api.one
+    def unpack(self):
+        if self.edi_type.id == self.env.ref('edi_af_as_notes.edi_af_as_notes_post').id:
+            # decode string and convert string to tuple, convert tuple to dict
+            body = dict(ast.literal_eval(self.body.decode("utf-8")))
+            
+            #NOT IMPLEMENTED
+
+            daily_note_id = False#self.env['calendar.schedule'].search([('type_id','=',type_id.id), ('start','=',start_time_utc)])
+            if daily_note_id:
+                # Update existing schedule only two values can change 
+                vals = {
+                    
+                }
+                daily_note_id.update(vals)
+            else:
+                # create new schedule
+                vals = {
+
+                }
+                schedule_id = self.env['res.partner.notes'].create(vals)
+            # TODO: maybe move this
+            schedule_id.create_occasions()
+        
+        else:
+            super(edi_message, self).unpack()
+
+    @api.one
+    def pack(self):
+        if self.edi_type.id == self.env.ref('edi_af_as_notes.edi_af_as_notes_post').id:
+            if not self.model_record or self.model_record._name != 'res.partner.notesq':
+                raise Warning("Appointment: Attached record is not an daily note! {model}".format(model=self.model_record and self.model_record._name or None))
+
+            obj = self.model_record
+            self.body = self.edi_type.type_mapping.format(
+                path = "",
+                
+            )
+            envelope = self.env['edi.envelope'].create({
+                'name': 'Jobseeker Daily Note request',
+                'route_id': self.route_id.id,
+                'route_type': self.route_type,
+                # 'recipient': self.recipient.id,
+                # 'sender': self.env.ref('base.main_partner').id,
+                # 'application': app.name,
+                # 'edi_message_ids': [(6, 0, msg_ids)]
+                'edi_message_ids': [(6, 0, [self.id])]
+            })
+            # TODO: Decide if we want to fold here?
+            # envelope.fold()
+            
+        else:
+            super(edi_message, self).pack()

--- a/edi_af_bar_arbetsuppgifter/messages/af_post_as_note.py
+++ b/edi_af_bar_arbetsuppgifter/messages/af_post_as_note.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution, third party addon
+#    Copyright (C) 2004-2020 Vertel AB (<http://vertel.se>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from odoo import models, fields, api, _
+from datetime import datetime, timedelta
+import json
+import pytz
+import ast
+
+import logging
+_logger = logging.getLogger(__name__)
+
+class edi_message(models.Model):
+    _inherit='edi.message'
+            
+    @api.one
+    def unpack(self):
+        if self.edi_type.id == self.env.ref('edi_af_as_notes.edi_af_as_notes_post').id: 
+            # decode string and convert string to tuple, convert tuple to dict
+            body = dict(ast.literal_eval(self.body.decode("utf-8")))
+            _logger.warn("RAPID reply: %s" % body)
+        else:
+            super(edi_message, self).unpack()
+
+    @api.one
+    def pack(self):
+        if self.edi_type.id == self.env.ref('edi_af_as_notes.edi_af_as_notes_post').id:
+            if not self.model_record or self.model_record._name != 'res.partner.notes' or not self.model_record.partner_id.is_jobseeker:
+                raise Warning("Appointment: Attached record is not an daily note! {model}".format(model=self.model_record and self.model_record._name or None))
+
+            obj = self.model_record
+            body_dict = {}
+            body_dict['base_url'] = self.edi_type.type_mapping.format(
+                path = "ais-f-daganteckningar/v1/anteckning",
+            )
+            body_dict['data'] = {
+                "entitetsId": obj.customer_id, 
+                "anteckningtypId": obj.note_type.name,
+                "handelsetidpunkt": obj.note_date.strftime("%Y-%m-%d"),
+                "ansvarKontor": obj.office.office_code,
+                "ansvarSignatur": obj.administrative_officer.login,
+                "avsandandeSystem": "CRM", 
+                "avsandandeSystemReferens": "null",
+                "lank": "null",
+                "text": obj.note,
+                "rubrik": obj.name,
+                "redigerbar": "A",
+                "sekretess": 'true' if obj.is_confidential else 'false',
+                "samtycke": 'false'
+            }
+            #_logger.info('administrative_officer login: %s' % obj.administrative_officer)
+            #_logger.info(body_dict['data'])
+            self.body = tuple(sorted(body_dict.items()))
+
+            envelope = self.env['edi.envelope'].create({
+                'name': 'Jobseeker daily note post',
+                'route_id': self.route_id.id,
+                'route_type': self.route_type,
+                'edi_message_ids': [(6, 0, [self.id])]
+            })
+            
+        else:
+            super(edi_message, self).pack()

--- a/edi_af_bar_arbetsuppgifter/models/__init__.py
+++ b/edi_af_bar_arbetsuppgifter/models/__init__.py
@@ -1,0 +1,1 @@
+from . import edi_route

--- a/edi_af_bar_arbetsuppgifter/models/edi_route.py
+++ b/edi_af_bar_arbetsuppgifter/models/edi_route.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution, third party addon
+#    Copyright (C) 2004-2016 Vertel AB (<http://vertel.se>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from odoo import models, fields, api, _
+import base64
+from datetime import datetime
+
+import logging
+_logger = logging.getLogger(__name__)
+
+class edi_envelope(models.Model):
+    _inherit = 'edi.envelope' 
+    
+    route_type = fields.Selection(selection_add=[('edi_af_as_notes_post', 'AF asok notes post'),('edi_af_as_notes_get', 'AF asok notes get')])
+
+    @api.one
+    def fold(self,route): # Folds messages in an envelope
+        # TODO: do we need to do something here?
+        # for m in self.env['edi.message'].search([('envelope_id','=',None),('route_id','=',route.id)]):
+        #     m.envelope_id = self.id
+        envelope = super(edi_envelope,self).fold(route)
+        return envelope
+
+    @api.one
+    def _split(self):
+        if self.route_type == 'edi_af_schedules':
+            msg = self.env['edi.message'].create({
+                'name': 'plain',
+                'envelope_id': self.id,
+                'body': self.body,
+                'route_type': self.route_type,
+                'sender': self.sender,
+                'recipient': self.recipient,
+                #~ 'consignor_id': sender.id,
+                #~ 'consignee_id': recipient.id,
+            })
+            msg.unpack()
+        self.envelope_opened()
+
+class edi_route(models.Model):
+    _inherit = 'edi.route' 
+    
+    route_type = fields.Selection(selection_add=[('edi_af_as_notes_post', 'AF asok notes post'),('edi_af_as_notes_get', 'AF asok notes get')])
+
+class edi_message(models.Model):
+    _inherit='edi.message'
+          
+    route_type = fields.Selection(selection_add=[('edi_af_as_notes_post', 'AF asok notes post'),('edi_af_as_notes_get', 'AF asok notes get')])

--- a/edi_af_bar_arbetsuppgifter/views/edi_af_as_notes_views.xml
+++ b/edi_af_bar_arbetsuppgifter/views/edi_af_as_notes_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="af_edi_as_notes" model="ir.actions.server">
+        <field name="name">EDI AF post note</field>
+        <field name="model_id" ref="base.model_ir_actions_server"/>
+        <field name="state">code</field>
+        <field name="code">
+route = env['edi.route'].search([('id', '=', env['ir.model.data'].xmlid_to_res_id('edi_af_as_notes.asok_note_post_route'))])
+
+note_vals = {
+    'name': "Test",
+    'note': "Test",
+    'note_date': "2020-08-31",
+    'administrative_officer': env['res.users'].browse(env['ir.model.data'].xmlid_to_res_id('edi_af_appointment.user_sunea')).id,
+    'is_confidential': False,
+    'note_type': env['res.partner.note.type'].browse(1).id,
+    'office': env['res.partner'].browse(env['ir.model.data'].xmlid_to_res_id('__ais_import__.part_office_2050')).id,
+    'partner_id': env['res.partner'].browse(env['ir.model.data'].xmlid_to_res_id('__ais_import__.part_jbskr_2280')).id,
+}
+
+record = env['res.partner.notes'].create(note_vals)
+
+vals = {
+  'name': 'post note msg',
+  'edi_type': env.ref('edi_af_as_notes.edi_af_as_notes_post').id,
+  'model': record._name,
+  'res_id': record.id,
+  'route_id': route.id,
+  'route_type': 'edi_af_as_notes_post',
+}
+
+message = env['edi.message'].create(vals)
+message.pack()
+route.run()
+        
+        
+        </field>
+    </record>
+
+ 
+</odoo>

--- a/edi_route_ipf/models/edi_route.py
+++ b/edi_route_ipf/models/edi_route.py
@@ -61,13 +61,17 @@ class ipf_rest(_ipf):
         """ Returns an uuid as an unique tracking id"""
         return str(uuid.uuid4())
 
-    def _generate_ctx(self, verify_ssl):
+    def _generate_ctx(self,route):
         ctx = ssl.create_default_context()
-        if verify_ssl:
+        if route.ssl_protocol == 'mutual': # mTLS
+            # Define the client certificate settings for https connection
+            # https://www.techcoil.com/blog/how-to-send-a-http-request-with-client-certificate-private-key-password-secret-in-python-3/
+            ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            ctx.load_cert_chain(certfile=route_id.ssl_certfile, keyfile=route_id.ssl_keyfile)
+        elif route.ssl_protocol == 'simple':
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
-        else:
-            pass # TODO: implement mTSL here!!!
+        #else: # route.ssl_protocol == 'no_verifiaction';
         return ctx
 
     def _generate_headers(self, af_environment, af_system_id, af_tracking_id):
@@ -289,7 +293,7 @@ class ipf_rest(_ipf):
             req = request.Request(url=get_url, data=data_vals, headers=get_headers)
         else:
             req = request.Request(url=get_url, headers=get_headers)
-        ctx = self._generate_ctx(True) # TODO: change to False
+        ctx = self._generate_ctx(message.route_id) # TODO: change to False
         # send GET and read result
         res_json = request.urlopen(req, context=ctx).read()
         # Convert json to python format: https://docs.python.org/3/library/json.html#json-to-py-table 
@@ -344,6 +348,11 @@ class edi_route(models.Model):
     # af_tracking_id = fields.Char(string='AF-TrackingId',help="If you need help you shouldn't be changing this")
     
     protocol = fields.Selection(selection_add=[('ipf', 'IPF')])
+    ssl_protocol = fields.Selection(selection=[('no_verfy','No verification'),('simple','Simple verification'),('mutual','Mutual verification (mTLS)')],string='SSL-Protocol')
+    ssl_certfile = fields.Char(string='SSL Cert File Path',help="Path of the X.509 certificate file in PEM(Privacy Enhanced Email) format")
+    ssl_keyfile = fields.Char(string='SSL Key File Path',help="Path of the X.509 private key of the certificate")
+    # https://www.techcoil.com/blog/how-to-send-a-http-request-with-client-certificate-private-key-password-secret-in-python-3/
+    # https://pythontic.com/ssl/sslcontext/load_cert_chain
 
     @api.multi
     def _run_in(self):
@@ -377,7 +386,18 @@ class edi_route(models.Model):
             try:
                 for envelope in envelopes:
                     for msg in envelope.edi_message_ids:
-                        endpoint = ipf_rest(host=self.af_ipf_url, username=self.af_client_id, password=self.af_client_secret, port=self.af_ipf_port, environment=self.af_environment, sys_id=self.af_system_id, authorization=self.af_authorization_header)
+                        endpoint = ipf_rest(
+                                    host=self.af_ipf_url, 
+                                    username=self.af_client_id, 
+                                    password=self.af_client_secret, 
+                                    port=self.af_ipf_port, 
+                                    environment=self.af_environment, 
+                                    sys_id=self.af_system_id, 
+                                    authorization=self.af_authorization_header,
+                                    ssl_protocol=self.ssl_protocol,
+                                    ssl_certfile=self.ssl_certfile,
+                                    ssl_keyfile=self.ssl_keyfile,
+                                    )
                         res_messages = endpoint.get(msg)
                         msg.state = 'sent'
                     

--- a/edi_route_ipf/views/edi_route_view.xml
+++ b/edi_route_ipf/views/edi_route_view.xml
@@ -16,7 +16,11 @@
                     <field name="af_client_id" nolabel="1" attrs="{'invisible': [('protocol','not in',['ipf'])], 'required': [('protocol','in',['ipf'])]}"/>
                     <label for="af_client_secret" string="Client Secret" attrs="{'invisible': [('protocol','not in',['ipf'])], 'required': [('protocol','in',['ipf'])]}"/>
                     <field name="af_client_secret" password="True" nolabel="1" attrs="{'invisible': [('protocol','not in',['ipf'])], 'required': [('protocol','in',['ipf'])]}"/>
+                    <field name="ssl_protocol" attrs="{'invisible': [('protocol','not in',['ipf'])]}"/>
+                    <field name="ssl_certfile" attrs="{'invisible': [('protocol','not in',['ipf'])]}"/>
+                    <field name="ssl_keyfile" attrs="{'invisible': [('protocol','not in',['ipf'])]}"/>
                     <label for="af_environment" string="AF-Environment" attrs="{'invisible': [('protocol','not in',['ipf'])], 'required': [('protocol','in',['ipf'])]}"/>
+                    
                     <field name="af_environment" nolabel="1" attrs="{'invisible': [('protocol','not in',['ipf'])], 'required': [('protocol','in',['ipf'])]}"/>
                     <label for="af_system_id" string="AF-SystemId" attrs="{'invisible': [('protocol','not in',['ipf'])], 'required': [('protocol','in',['ipf'])]}"/>
                     <field name="af_system_id" nolabel="1" attrs="{'invisible': [('protocol','not in',['ipf'])], 'required': [('protocol','in',['ipf'])]}"/>


### PR DESCRIPTION
Möjlighet till mTLS inlagd på rutten IPF

Konfigurera rutten med cert/nyckel-fil Robin har tagit ut sådana åt oss.

https://www.techcoil.com/blog/how-to-send-a-http-request-with-client-certificate-private-key-password-secret-in-python-3/
https://pythontic.com/ssl/sslcontext/load_cert_chain

